### PR TITLE
Use HTTPS for geoip requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This is a modified version of the CustomTube theme with the import functionality
 3. **Modified Files**:
    - `functions.php` - Updated to remove import functionality
    - Various admin files - Removed import-related code
+4. **Geo-IP Service**: The ad system now queries `https://ip-api.com` for
+   country lookups over HTTPS.
 
 ## Installation
 

--- a/inc/ads.php
+++ b/inc/ads.php
@@ -390,7 +390,7 @@ function customtube_get_user_ip() {
  */
 function customtube_geoip_lookup($ip) {
     // Use a free geo-IP service (consider ip-api.com, ipinfo.io, etc.)
-    $api_url = "http://ip-api.com/json/{$ip}?fields=countryCode";
+    $api_url = "https://ip-api.com/json/{$ip}?fields=countryCode";
     
     $response = wp_remote_get($api_url, array(
         'timeout' => 3,


### PR DESCRIPTION
## Summary
- switch geo-IP service URL to `https://ip-api.com`
- note new HTTPS usage in README
- ignore `node_modules`

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68719047c3c483278051e12df0440b11