### PR TITLE
Add ignore rules for common build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 node_modules/
+
+# Ignore build artifacts
+dist/
+*.log
+# macOS system files
+.DS_Store
+# Windows system files
+Thumbs.db
+# Vim swap files
+*.swp


### PR DESCRIPTION
## Summary
- update `.gitignore` with typical build outputs and system files

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871987263d88327b3d446db6b529b9e