### PR TITLE
Add reusable trending videos query

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -891,3 +891,23 @@ add_filter('theme_page_templates', 'customtube_register_page_templates');
  * @param int $count Number of videos to retrieve
  * @return WP_Query
  */
+function customtube_get_trending_videos( $count = 10 ) {
+    $args = array(
+        'post_type'      => 'video',
+        'post_status'    => 'publish',
+        'posts_per_page' => $count,
+        'meta_query'     => array(
+            array(
+                'key'     => 'video_file',
+                'compare' => 'EXISTS',
+            ),
+        ),
+        'orderby'        => array(
+            'meta_value_num' => 'DESC',
+            'date'           => 'DESC',
+        ),
+        'meta_key'       => 'video_views',
+    );
+
+    return new WP_Query( $args );
+}

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -1971,29 +1971,7 @@ function customtube_get_page_template($page_template) {
 }
 add_filter('page_template', 'customtube_get_page_template');
 
-/**
- * Query helper: trending videos
- */
-if (!function_exists('customtube_get_trending_videos')) {
-function customtube_get_trending_videos($count = 8) {
-    $cache_key = 'customtube_trending_videos_' . $count;
-    $query = get_transient($cache_key);
 
-    if (false === $query) {
-        $args = array(
-            'post_type'      => 'video',
-            'posts_per_page' => $count,
-            'meta_key'       => 'video_views',
-            'orderby'        => 'meta_value_num',
-            'order'          => 'DESC',
-            'post_status'    => 'publish',
-        );
-        $query = new WP_Query($args);
-        set_transient($cache_key, $query, HOUR_IN_SECONDS);
-    }
-    return $query;
-}
-}
 
 /**
  * Query helper: recent videos


### PR DESCRIPTION
## Summary
- implement `customtube_get_trending_videos()` helper
- remove old version from `template-functions.php`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6871cc5d461083278a8fcd75e994fcfd