### PR TITLE
Add translation framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,23 @@ If you encounter errors:
 ## Migration
 
 This version was created using the migration script in the theme directory. For details on the migration process, see MIGRATION-GUIDE.md.
+
+## Translations
+
+The theme's translatable strings live in `languages/customtube.pot`.
+
+1. Regenerate this POT file from the theme root when strings change:
+
+   ```bash
+   find . -path ./languages -prune -o -name '*.php' -print | \
+     xargs xgettext --from-code=UTF-8 -L PHP \
+       -k__ -k_e -k_x:1,2c -k_ex:1,2c -k_n:1,2 -k_nx:1,2,4c \
+       -kesc_html__ -kesc_html_e -kesc_html_x:1,2c \
+       -kesc_attr__ -kesc_attr_e -kesc_attr_x:1,2c \
+       -o languages/customtube.pot
+   ```
+
+2. Use Poedit or WP‑CLI to create `.po` and `.mo` files from `customtube.pot`.
+3. Save the resulting `.mo` files in the `languages/` directory using locale-based filenames (e.g. `customtube-fr_FR.mo`).
+
+WordPress automatically loads the correct translation based on the site language.

--- a/functions.php
+++ b/functions.php
@@ -53,6 +53,8 @@ require_once CUSTOMTUBE_DIR . '/inc/template-functions.php';
 
 // Theme Setup
 function customtube_theme_setup() {
+    // Enable translations
+    load_theme_textdomain( 'customtube', CUSTOMTUBE_DIR . '/languages' );
     add_theme_support('title-tag');
     add_theme_support('post-thumbnails');
     add_theme_support('automatic-feed-links');

--- a/languages/customtube.pot
+++ b/languages/customtube.pot
@@ -1,0 +1,4176 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-12 03:08+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: functions.php:62
+msgid "Primary Menu"
+msgstr ""
+
+#: functions.php:63
+msgid "Footer Menu"
+msgstr ""
+
+#: functions.php:138 inc/taxonomies.php:331
+msgid "Sidebar"
+msgstr ""
+
+#: functions.php:140
+msgid "Add widgets here."
+msgstr ""
+
+#: functions.php:148
+msgid "Footer Widgets"
+msgstr ""
+
+#: functions.php:150
+msgid "Add footer widgets here."
+msgstr ""
+
+#: header.php:13
+msgid "Skip to content"
+msgstr ""
+
+#: page-performers.php:97 template-parts/pages/page-home.php:88
+#: template-parts/pages/page-performers.php:97
+#: template-parts/pages/page-categories.php:238
+#, php-format
+msgid "%s video"
+msgid_plural "%s videos"
+msgstr[0] ""
+msgstr[1] ""
+
+#: page-performers.php:110 inc/template-functions.php:1500
+#: inc/taxonomies.php:143 inc/taxonomies.php:514
+#: template-parts/pages/page-performers.php:110
+msgid "No performers found."
+msgstr ""
+
+#: inc/template-functions.php:58
+msgctxt "placeholder"
+msgid "Search videos..."
+msgstr ""
+
+#: inc/template-functions.php:378 inc/template-functions.php:1021
+#: inc/video-embed.php:240 inc/video-embed.php:478
+msgid "No video source provided."
+msgstr ""
+
+#: inc/template-functions.php:379
+msgid "Please edit this video and add a direct video URL."
+msgstr ""
+
+#: inc/template-functions.php:780
+msgid "Invalid embed code detected."
+msgstr ""
+
+#: inc/template-functions.php:781 inc/template-functions.php:849
+msgid "Please edit this video and add a valid video URL or embed code."
+msgstr ""
+
+#: inc/template-functions.php:836
+msgid "Invalid iframe code detected."
+msgstr ""
+
+#: inc/template-functions.php:837
+msgid ""
+"Please edit this video and add a valid embed code with proper src attribute."
+msgstr ""
+
+#: inc/template-functions.php:848
+msgid "Invalid video source detected."
+msgstr ""
+
+#: inc/template-functions.php:1022 inc/video-embed.php:241
+#: inc/video-embed.php:479
+msgid "Please edit this video and add a video URL in the Video Details box."
+msgstr ""
+
+#: inc/template-functions.php:1107
+msgid "Related Videos"
+msgstr ""
+
+#: inc/template-functions.php:1217
+msgid "Performers:"
+msgstr ""
+
+#: inc/template-functions.php:1246
+msgid "Tags:"
+msgstr ""
+
+#: inc/template-functions.php:1292 template-parts/pages/page-shorties.php:17
+msgid "Short Videos"
+msgstr ""
+
+#: inc/template-functions.php:1293
+msgid "No short videos found. Try adding videos less than 5 minutes long."
+msgstr ""
+
+#: inc/template-functions.php:1295 inc/post-types.php:30
+#: template-parts/video-grid.php:16
+msgid "No videos found."
+msgstr ""
+
+#: inc/template-functions.php:1373 sitemap.php:44
+msgid "views"
+msgstr ""
+
+#: inc/template-functions.php:1394
+msgid "Liked"
+msgstr ""
+
+#: inc/template-functions.php:1396
+msgid "Like"
+msgstr ""
+
+#: inc/template-functions.php:1414
+msgid "Share"
+msgstr ""
+
+#: inc/template-functions.php:1549
+msgid "No performers starting with this letter."
+msgstr ""
+
+#: inc/template-functions.php:1636
+msgid "Loading more videos..."
+msgstr ""
+
+#: inc/template-functions.php:1639
+msgid "You've reached the end!"
+msgstr ""
+
+#: inc/template-functions.php:1642
+msgid "Error loading videos"
+msgstr ""
+
+#: inc/video-metadata.php:200
+msgid "No video source provided"
+msgstr ""
+
+#: inc/video-metadata.php:849
+msgid "Fetch Video Metadata"
+msgstr ""
+
+#: inc/video-metadata.php:865 inc/meta-boxes.php:202
+#: inc/thumbnail-extractor.php:453
+msgid "Please enter a video URL or embed code first."
+msgstr ""
+
+#: inc/video-metadata.php:889
+msgid "Metadata fetched successfully!"
+msgstr ""
+
+#: inc/video-metadata.php:895 inc/meta-boxes.php:507
+msgid "Error fetching metadata. Please try again."
+msgstr ""
+
+#: inc/video-metadata.php:931 inc/modules/clip-management.php:880
+#: inc/modules/clip-management.php:942 inc/modules/ajax-handlers.php:20
+#: inc/modules/ajax-handlers.php:103 inc/modules/ajax-handlers.php:185
+#: inc/modules/ajax-handlers.php:421 inc/thumbnail-extractor.php:508
+#: inc/admin/ffmpeg-settings.php:344 inc/admin/ffmpeg-settings.php:394
+#: inc/admin/ffmpeg-settings.php:581
+msgid "Security check failed."
+msgstr ""
+
+#: inc/video-metadata.php:936 inc/modules/ajax-handlers.php:108
+#: inc/modules/ajax-handlers.php:190 inc/modules/ajax-handlers.php:426
+#: inc/thumbnail-extractor.php:513
+msgid "Missing required data."
+msgstr ""
+
+#: inc/video-metadata.php:945 inc/modules/clip-management.php:893
+#: inc/modules/clip-management.php:954 inc/modules/ajax-handlers.php:119
+#: inc/modules/ajax-handlers.php:225 inc/thumbnail-extractor.php:366
+#: inc/thumbnail-extractor.php:522
+msgid "You do not have permission to edit this post."
+msgstr ""
+
+#: inc/video-metadata.php:1008
+msgid "Video Metadata Settings"
+msgstr ""
+
+#: inc/video-metadata.php:1015
+msgid "YouTube API Key"
+msgstr ""
+
+#: inc/video-metadata.php:1029
+msgid "API keys for fetching video metadata from various services."
+msgstr ""
+
+#: inc/video-metadata.php:1038
+msgid "Enter your YouTube Data API key for fetching video metadata."
+msgstr ""
+
+#: inc/video-metadata.php:1038
+msgid "Get API Key"
+msgstr ""
+
+#: inc/post-types.php:18
+msgctxt "Post type general name"
+msgid "Videos"
+msgstr ""
+
+#: inc/post-types.php:19
+msgctxt "Post type singular name"
+msgid "Video"
+msgstr ""
+
+#: inc/post-types.php:20
+msgctxt "Admin Menu text"
+msgid "Videos"
+msgstr ""
+
+#: inc/post-types.php:21
+msgctxt "Add New on Toolbar"
+msgid "Video"
+msgstr ""
+
+#: inc/post-types.php:22 inc/post-types.php:72
+msgid "Add New"
+msgstr ""
+
+#: inc/post-types.php:23 inc/admin/dashboard.php:43 inc/admin/dashboard.php:158
+msgid "Add New Video"
+msgstr ""
+
+#: inc/post-types.php:24
+msgid "New Video"
+msgstr ""
+
+#: inc/post-types.php:25
+msgid "Edit Video"
+msgstr ""
+
+#: inc/post-types.php:26
+msgid "View Video"
+msgstr ""
+
+#: inc/post-types.php:27 archive-video.php:42
+msgid "All Videos"
+msgstr ""
+
+#: inc/post-types.php:28
+msgid "Search Videos"
+msgstr ""
+
+#: inc/post-types.php:29
+msgid "Parent Videos:"
+msgstr ""
+
+#: inc/post-types.php:31
+msgid "No videos found in Trash."
+msgstr ""
+
+#: inc/post-types.php:32
+msgctxt "Overrides the \"Featured Image\" phrase"
+msgid "Video Thumbnail"
+msgstr ""
+
+#: inc/post-types.php:33
+msgctxt "Overrides the \"Set featured image\" phrase"
+msgid "Set video thumbnail"
+msgstr ""
+
+#: inc/post-types.php:34
+msgctxt "Overrides the \"Remove featured image\" phrase"
+msgid "Remove video thumbnail"
+msgstr ""
+
+#: inc/post-types.php:35
+msgctxt "Overrides the \"Use as featured image\" phrase"
+msgid "Use as video thumbnail"
+msgstr ""
+
+#: inc/post-types.php:36
+msgctxt "The post type archive label used in nav menus"
+msgid "Video archives"
+msgstr ""
+
+#: inc/post-types.php:37
+msgctxt "Overrides the \"Insert into post\" phrase"
+msgid "Insert into video"
+msgstr ""
+
+#: inc/post-types.php:38
+msgctxt "Overrides the \"Uploaded to this post\" phrase"
+msgid "Uploaded to this video"
+msgstr ""
+
+#: inc/post-types.php:39
+msgctxt "Screen reader text for the filter links"
+msgid "Filter videos list"
+msgstr ""
+
+#: inc/post-types.php:40
+msgctxt "Screen reader text for the pagination"
+msgid "Videos list navigation"
+msgstr ""
+
+#: inc/post-types.php:41
+msgctxt "Screen reader text for the items list"
+msgid "Videos list"
+msgstr ""
+
+#: inc/post-types.php:68
+msgctxt "Post type general name"
+msgid "Ads"
+msgstr ""
+
+#: inc/post-types.php:69
+msgctxt "Post type singular name"
+msgid "Ad"
+msgstr ""
+
+#: inc/post-types.php:70
+msgctxt "Admin Menu text"
+msgid "Ads"
+msgstr ""
+
+#: inc/post-types.php:71
+msgctxt "Add New on Toolbar"
+msgid "Ad"
+msgstr ""
+
+#: inc/post-types.php:73
+msgid "Add New Ad"
+msgstr ""
+
+#: inc/post-types.php:74
+msgid "New Ad"
+msgstr ""
+
+#: inc/post-types.php:75
+msgid "Edit Ad"
+msgstr ""
+
+#: inc/post-types.php:76
+msgid "View Ad"
+msgstr ""
+
+#: inc/post-types.php:77
+msgid "All Ads"
+msgstr ""
+
+#: inc/post-types.php:78
+msgid "Search Ads"
+msgstr ""
+
+#: inc/post-types.php:79
+msgid "Parent Ads:"
+msgstr ""
+
+#: inc/post-types.php:80
+msgid "No ads found."
+msgstr ""
+
+#: inc/post-types.php:81
+msgid "No ads found in Trash."
+msgstr ""
+
+#: inc/post-types.php:262
+msgid "Enter video title here"
+msgstr ""
+
+#: inc/post-types.php:277 inc/admin/dashboard.php:124
+#: inc/admin/dashboard.php:180
+msgid "Thumbnail"
+msgstr ""
+
+#: inc/post-types.php:279 archive-video.php:73
+#: template-parts/pages/page-likedvideos.php:106
+msgid "Duration"
+msgstr ""
+
+#: inc/post-types.php:280 inc/admin/dashboard.php:127
+#: inc/admin/dashboard.php:182
+msgid "Views"
+msgstr ""
+
+#: inc/meta-boxes.php:20
+msgid "Video Details"
+msgstr ""
+
+#: inc/meta-boxes.php:63 inc/modules/admin-ui.php:58
+#: inc/modules/admin-ui.php:77 inc/modules/admin-ui.php:279
+msgid "Paste Video URL"
+msgstr ""
+
+#: inc/meta-boxes.php:64 inc/modules/admin-ui.php:59
+#: inc/modules/admin-ui.php:78 inc/modules/admin-ui.php:182
+#: inc/modules/admin-ui.php:280
+msgid ""
+"Simply paste any video URL (YouTube, Vimeo, PornHub, XVideos, direct MP4, "
+"etc.) and fields will be automatically populated."
+msgstr ""
+
+#: inc/meta-boxes.php:67 inc/modules/admin-ui.php:60
+#: inc/modules/admin-ui.php:81 inc/modules/admin-ui.php:185
+#: inc/modules/admin-ui.php:281
+msgid "Paste or type video URL here - auto-detection happens immediately"
+msgstr ""
+
+#: inc/meta-boxes.php:84
+msgid "Video URL"
+msgstr ""
+
+#: inc/meta-boxes.php:88
+msgid ""
+"Paste any video URL here - YouTube, Vimeo, PornHub, or direct MP4 video "
+"links all work."
+msgstr ""
+
+#: inc/meta-boxes.php:91
+msgid "Test Video URL"
+msgstr ""
+
+#: inc/meta-boxes.php:99
+msgid "Supported URL Types"
+msgstr ""
+
+#: inc/meta-boxes.php:112
+msgid "Quality Options"
+msgstr ""
+
+#: inc/meta-boxes.php:114
+msgid "Optional alternate quality URLs (only for MP4 videos)"
+msgstr ""
+
+#: inc/meta-boxes.php:133
+msgid "Preview Video URL (hover)"
+msgstr ""
+
+#: inc/meta-boxes.php:137
+msgid "Enter a short preview video URL for thumbnail hover (optional)"
+msgstr ""
+
+#: inc/meta-boxes.php:143
+msgid "Video Duration"
+msgstr ""
+
+#: inc/meta-boxes.php:150
+msgid ""
+"Enter duration in MM:SS or HH:MM:SS format or click \"Auto-detect\" to fetch "
+"it automatically"
+msgstr ""
+
+#: inc/meta-boxes.php:153
+msgid "Auto-detect"
+msgstr ""
+
+#: inc/meta-boxes.php:172 inc/meta-boxes.php:278
+msgid "Video Preview"
+msgstr ""
+
+#: inc/meta-boxes.php:179 inc/meta-boxes.php:297
+msgid "No video URL provided."
+msgstr ""
+
+#: inc/meta-boxes.php:186 inc/thumbnail-extractor.php:345
+msgid "Extract Thumbnail"
+msgstr ""
+
+#: inc/meta-boxes.php:223
+msgid "Thumbnail successfully extracted and set!"
+msgstr ""
+
+#: inc/meta-boxes.php:232
+msgid "Error extracting thumbnail."
+msgstr ""
+
+#: inc/meta-boxes.php:236 inc/modules/admin-ui.php:63
+#: inc/modules/admin-ui.php:284
+msgid "Error communicating with the server."
+msgstr ""
+
+#: inc/meta-boxes.php:291
+msgid "Platform URL detected. The video will be embedded from the source site."
+msgstr ""
+
+#: inc/meta-boxes.php:292
+msgid "URL:"
+msgstr ""
+
+#: inc/meta-boxes.php:307
+msgid "Please enter a video URL to test"
+msgstr ""
+
+#: inc/meta-boxes.php:321
+msgid "Testing..."
+msgstr ""
+
+#: inc/meta-boxes.php:327
+msgid "The video URL could not be loaded. Please check the URL and try again."
+msgstr ""
+
+#: inc/meta-boxes.php:339
+msgid "Video URL is valid! Duration detected: "
+msgstr ""
+
+#: inc/meta-boxes.php:344
+msgid "Error loading video. Please check the URL and try again."
+msgstr ""
+
+#: inc/meta-boxes.php:459
+msgid "Please enter a video URL first."
+msgstr ""
+
+#: inc/meta-boxes.php:500
+msgid "Metadata successfully detected!"
+msgstr ""
+
+#: inc/meta-boxes.php:503
+msgid "Error fetching metadata."
+msgstr ""
+
+#: inc/video-embed.php:422
+msgid "Error detecting video: "
+msgstr ""
+
+#: inc/ad-meta-boxes.php:18
+msgid "Ad Settings"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:27
+msgid "Targeting Options"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:36
+msgid "Impression & Click Limits"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:45
+msgid "Ad Statistics"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:73
+msgid "Ad Status"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:77
+msgid "Active"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:78
+msgid "Inactive"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:79
+msgid "Paused"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:81
+msgid "Control whether this ad is displayed on the site."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:87
+msgid "Ad Type"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:91 inc/ad-meta-boxes.php:102
+msgid "HTML/JavaScript Code"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:92
+msgid "Image Banner"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:93
+msgid "VAST Video Ad"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:95
+msgid "Select the type of ad content."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:106
+msgid "Ad Code"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:110
+msgid "Paste your ad network code (HTML, JavaScript, etc.) here."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:118
+msgid "Image Banner Settings"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:122
+msgid "Image URL"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:126
+msgid "Upload Image"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:127
+msgid "URL of the ad image."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:133
+msgid "Click URL"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:137
+msgid "URL to redirect when the ad is clicked."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:143
+msgid "Width"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:147
+msgid "Width in pixels or \"auto\". Examples: 728, 300, auto"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:153
+msgid "Height"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:157
+msgid "Height in pixels or \"auto\". Examples: 90, 250, auto"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:164
+msgid "Advanced Settings"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:168
+msgid "CSS Class"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:172
+msgid "Additional CSS classes for styling (optional)."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:190
+msgid "Choose Ad Image"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:192
+msgid "Choose Image"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:227
+msgid "Start Date"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:231
+msgid "Leave empty for no start date restriction."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:237
+msgid "End Date"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:241
+msgid "Leave empty for no end date restriction."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:247
+msgid "Device Targeting"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:253
+msgid "Desktop"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:258
+msgid "Tablet"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:263
+msgid "Mobile"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:266
+msgid "Leave unchecked to show on all devices."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:272
+msgid "Geographic Targeting"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:276
+msgid "No geographic targeting"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:277
+msgid "Include only these countries"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:278
+msgid "Exclude these countries"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:285
+msgid "Country Codes"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:289
+msgid ""
+"Enter 2-letter country codes separated by commas (e.g., US, GB, CA, DE)."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:319
+msgid "Max Impressions"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:323
+msgid "0 = unlimited impressions"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:329
+msgid "Max Clicks"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:333
+msgid "0 = unlimited clicks"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:349
+msgid "Never"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:355
+msgid "Current Statistics:"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:358 inc/ad-meta-boxes.php:668
+msgid "Impressions:"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:359 inc/ad-meta-boxes.php:669
+msgid "Clicks:"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:360 inc/ad-meta-boxes.php:670
+msgid "CTR:"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:361
+msgid "Last Shown:"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:365
+msgid "Reset Statistics"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:374
+msgid "Are you sure you want to reset the statistics for this ad?"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:389
+msgid "Failed to reset statistics."
+msgstr ""
+
+#: inc/ad-meta-boxes.php:624 inc/modules/clip-management.php:744
+msgid "Type"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:625
+msgid "Status"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:629
+msgid "Stats"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:645
+msgid "HTML/JS"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:646
+msgid "Image"
+msgstr ""
+
+#: inc/ad-meta-boxes.php:647
+msgid "VAST"
+msgstr ""
+
+#: inc/branding.php:98
+msgid "Site Branding"
+msgstr ""
+
+#: inc/branding.php:99
+msgid "Customize site logo and branding options"
+msgstr ""
+
+#: inc/branding.php:110 inc/admin/settings.php:132
+msgid "Mobile Logo"
+msgstr ""
+
+#: inc/branding.php:111
+msgid "Upload a smaller logo optimized for mobile devices"
+msgstr ""
+
+#: inc/branding.php:124
+msgid "Show Site Title with Logo"
+msgstr ""
+
+#: inc/branding.php:125
+msgid "Display the site title alongside the logo"
+msgstr ""
+
+#: inc/modules/clip-management.php:727
+msgid "Video Clips"
+msgstr ""
+
+#: inc/modules/clip-management.php:730
+msgid ""
+"FFmpeg is not available. Clips functionality requires FFmpeg to be installed "
+"on the server."
+msgstr ""
+
+#: inc/modules/clip-management.php:736
+#, php-format
+msgid "Clips generated on %s."
+msgstr ""
+
+#: inc/modules/clip-management.php:745
+msgid "Format"
+msgstr ""
+
+#: inc/modules/clip-management.php:746
+msgid "Size"
+msgstr ""
+
+#: inc/modules/clip-management.php:747
+msgid "Actions"
+msgstr ""
+
+#: inc/modules/clip-management.php:757
+msgid "View"
+msgstr ""
+
+#: inc/modules/clip-management.php:767
+msgid "Regenerate Clips"
+msgstr ""
+
+#: inc/modules/clip-management.php:770
+msgid "Delete Clips"
+msgstr ""
+
+#: inc/modules/clip-management.php:774
+msgid "No clips have been generated for this video."
+msgstr ""
+
+#: inc/modules/clip-management.php:776
+msgid "Generate Clips"
+msgstr ""
+
+#: inc/modules/clip-management.php:818 inc/admin/ffmpeg-settings.php:565
+msgid "Error generating clips. Please try again."
+msgstr ""
+
+#: inc/modules/clip-management.php:829
+msgid "Are you sure you want to delete all clips for this video?"
+msgstr ""
+
+#: inc/modules/clip-management.php:860
+msgid "Error deleting clips. Please try again."
+msgstr ""
+
+#: inc/modules/clip-management.php:885 inc/modules/clip-management.php:947
+#: inc/thumbnail-extractor.php:357 inc/admin/ffmpeg-settings.php:586
+msgid "No post ID provided."
+msgstr ""
+
+#: inc/modules/clip-management.php:899 inc/modules/clip-management.php:960
+#: inc/thumbnail-extractor.php:372 inc/admin/ffmpeg-settings.php:600
+msgid "Invalid post type."
+msgstr ""
+
+#: inc/modules/clip-management.php:905
+msgid ""
+"Clips already exist for this video. Use regenerate option to create new "
+"clips."
+msgstr ""
+
+#: inc/modules/clip-management.php:927 inc/admin/ffmpeg-settings.php:617
+msgid "Clips generated successfully."
+msgstr ""
+
+#: inc/modules/clip-management.php:973
+msgid "Clips deleted successfully."
+msgstr ""
+
+#: inc/modules/clip-management.php:976
+msgid "Failed to delete clips."
+msgstr ""
+
+#: inc/modules/ajax-handlers.php:25
+msgid "No URL provided."
+msgstr ""
+
+#: inc/modules/ajax-handlers.php:146
+msgid "Thumbnail set successfully!"
+msgstr ""
+
+#: inc/modules/ajax-handlers.php:172
+msgid "Failed to set thumbnail."
+msgstr ""
+
+#: inc/modules/ajax-handlers.php:249
+msgid "Failed to create post."
+msgstr ""
+
+#: inc/modules/ajax-handlers.php:405
+msgid "Metadata saved successfully!"
+msgstr ""
+
+#: inc/modules/admin-ui.php:61 inc/modules/admin-ui.php:282
+msgid "Video configured successfully!"
+msgstr ""
+
+#: inc/modules/admin-ui.php:62 inc/modules/admin-ui.php:283
+msgid "Error detecting URL."
+msgstr ""
+
+#: inc/modules/admin-ui.php:64 inc/modules/admin-ui.php:285
+msgid "Auto-populated:"
+msgstr ""
+
+#: inc/modules/admin-ui.php:65 inc/modules/admin-ui.php:286
+msgid "Thumbnail automatically set!"
+msgstr ""
+
+#: inc/modules/admin-ui.php:66 inc/modules/admin-ui.php:287
+msgid "Could not set thumbnail automatically."
+msgstr ""
+
+#: inc/modules/admin-ui.php:67 inc/modules/admin-ui.php:288
+msgid "Click \"Extract Thumbnail from Video\" to try manually."
+msgstr ""
+
+#: inc/modules/admin-ui.php:68 inc/modules/admin-ui.php:289
+msgid "Error setting thumbnail automatically."
+msgstr ""
+
+#: inc/modules/admin-ui.php:69 inc/modules/admin-ui.php:290
+msgid "Video data loaded! Click \"Publish\" when ready."
+msgstr ""
+
+#: inc/modules/admin-ui.php:70 inc/modules/admin-ui.php:291
+msgid "Video data loaded. Click \"Publish\" to save."
+msgstr ""
+
+#: inc/modules/admin-ui.php:167
+msgid "Auto-Detect Video URL"
+msgstr ""
+
+#: inc/taxonomies.php:18
+msgctxt "Taxonomy general name"
+msgid "Video Categories"
+msgstr ""
+
+#: inc/taxonomies.php:19
+msgctxt "Taxonomy singular name"
+msgid "Video Category"
+msgstr ""
+
+#: inc/taxonomies.php:20
+msgid "Search Video Categories"
+msgstr ""
+
+#: inc/taxonomies.php:21
+msgid "Popular Video Categories"
+msgstr ""
+
+#: inc/taxonomies.php:22
+msgid "All Video Categories"
+msgstr ""
+
+#: inc/taxonomies.php:23
+msgid "Parent Video Category"
+msgstr ""
+
+#: inc/taxonomies.php:24
+msgid "Parent Video Category:"
+msgstr ""
+
+#: inc/taxonomies.php:25
+msgid "Edit Video Category"
+msgstr ""
+
+#: inc/taxonomies.php:26
+msgid "View Video Category"
+msgstr ""
+
+#: inc/taxonomies.php:27
+msgid "Update Video Category"
+msgstr ""
+
+#: inc/taxonomies.php:28
+msgid "Add New Video Category"
+msgstr ""
+
+#: inc/taxonomies.php:29
+msgid "New Video Category Name"
+msgstr ""
+
+#: inc/taxonomies.php:30
+msgid "Separate video categories with commas"
+msgstr ""
+
+#: inc/taxonomies.php:31
+msgid "Add or remove video categories"
+msgstr ""
+
+#: inc/taxonomies.php:32
+msgid "Choose from the most used video categories"
+msgstr ""
+
+#: inc/taxonomies.php:33
+msgid "No video categories found."
+msgstr ""
+
+#: inc/taxonomies.php:34
+msgid "No video categories"
+msgstr ""
+
+#: inc/taxonomies.php:35
+msgid "Video Categories list navigation"
+msgstr ""
+
+#: inc/taxonomies.php:36
+msgid "Video Categories list"
+msgstr ""
+
+#: inc/taxonomies.php:37
+msgid "Back to video categories"
+msgstr ""
+
+#: inc/taxonomies.php:56
+msgctxt "Taxonomy general name"
+msgid "Video Tags"
+msgstr ""
+
+#: inc/taxonomies.php:57
+msgctxt "Taxonomy singular name"
+msgid "Video Tag"
+msgstr ""
+
+#: inc/taxonomies.php:58
+msgid "Search Video Tags"
+msgstr ""
+
+#: inc/taxonomies.php:59
+msgid "Popular Video Tags"
+msgstr ""
+
+#: inc/taxonomies.php:60
+msgid "All Video Tags"
+msgstr ""
+
+#: inc/taxonomies.php:61
+msgid "Parent Video Tag"
+msgstr ""
+
+#: inc/taxonomies.php:62
+msgid "Parent Video Tag:"
+msgstr ""
+
+#: inc/taxonomies.php:63
+msgid "Edit Video Tag"
+msgstr ""
+
+#: inc/taxonomies.php:64
+msgid "View Video Tag"
+msgstr ""
+
+#: inc/taxonomies.php:65
+msgid "Update Video Tag"
+msgstr ""
+
+#: inc/taxonomies.php:66
+msgid "Add New Video Tag"
+msgstr ""
+
+#: inc/taxonomies.php:67
+msgid "New Video Tag Name"
+msgstr ""
+
+#: inc/taxonomies.php:68
+msgid "Separate video tags with commas"
+msgstr ""
+
+#: inc/taxonomies.php:69
+msgid "Add or remove video tags"
+msgstr ""
+
+#: inc/taxonomies.php:70
+msgid "Choose from the most used video tags"
+msgstr ""
+
+#: inc/taxonomies.php:71
+msgid "No video tags found."
+msgstr ""
+
+#: inc/taxonomies.php:72
+msgid "No video tags"
+msgstr ""
+
+#: inc/taxonomies.php:73
+msgid "Video Tags list navigation"
+msgstr ""
+
+#: inc/taxonomies.php:74
+msgid "Video Tags list"
+msgstr ""
+
+#: inc/taxonomies.php:75
+msgid "Back to video tags"
+msgstr ""
+
+#: inc/taxonomies.php:94
+msgctxt "Taxonomy general name"
+msgid "Video Durations"
+msgstr ""
+
+#: inc/taxonomies.php:95
+msgctxt "Taxonomy singular name"
+msgid "Video Duration"
+msgstr ""
+
+#: inc/taxonomies.php:96
+msgid "Search Video Durations"
+msgstr ""
+
+#: inc/taxonomies.php:97
+msgid "Popular Video Durations"
+msgstr ""
+
+#: inc/taxonomies.php:98
+msgid "All Video Durations"
+msgstr ""
+
+#: inc/taxonomies.php:99
+msgid "Edit Video Duration"
+msgstr ""
+
+#: inc/taxonomies.php:100
+msgid "View Video Duration"
+msgstr ""
+
+#: inc/taxonomies.php:101
+msgid "Update Video Duration"
+msgstr ""
+
+#: inc/taxonomies.php:102
+msgid "Add New Video Duration"
+msgstr ""
+
+#: inc/taxonomies.php:103
+msgid "New Video Duration Name"
+msgstr ""
+
+#: inc/taxonomies.php:104
+msgid "Separate video durations with commas"
+msgstr ""
+
+#: inc/taxonomies.php:105
+msgid "Add or remove video durations"
+msgstr ""
+
+#: inc/taxonomies.php:106
+msgid "Choose from the most used video durations"
+msgstr ""
+
+#: inc/taxonomies.php:107
+msgid "No video durations found."
+msgstr ""
+
+#: inc/taxonomies.php:108
+msgid "No video durations"
+msgstr ""
+
+#: inc/taxonomies.php:109
+msgid "Video Durations list navigation"
+msgstr ""
+
+#: inc/taxonomies.php:110
+msgid "Video Durations list"
+msgstr ""
+
+#: inc/taxonomies.php:111
+msgid "Back to video durations"
+msgstr ""
+
+#: inc/taxonomies.php:130
+msgctxt "Taxonomy general name"
+msgid "Performers"
+msgstr ""
+
+#: inc/taxonomies.php:131
+msgctxt "Taxonomy singular name"
+msgid "Performer"
+msgstr ""
+
+#: inc/taxonomies.php:132
+msgid "Search Performers"
+msgstr ""
+
+#: inc/taxonomies.php:133
+msgid "Popular Performers"
+msgstr ""
+
+#: inc/taxonomies.php:134
+msgid "All Performers"
+msgstr ""
+
+#: inc/taxonomies.php:135
+msgid "Edit Performer"
+msgstr ""
+
+#: inc/taxonomies.php:136
+msgid "View Performer"
+msgstr ""
+
+#: inc/taxonomies.php:137
+msgid "Update Performer"
+msgstr ""
+
+#: inc/taxonomies.php:138
+msgid "Add New Performer"
+msgstr ""
+
+#: inc/taxonomies.php:139
+msgid "New Performer Name"
+msgstr ""
+
+#: inc/taxonomies.php:140
+msgid "Separate performers with commas"
+msgstr ""
+
+#: inc/taxonomies.php:141
+msgid "Add or remove performers"
+msgstr ""
+
+#: inc/taxonomies.php:142
+msgid "Choose from the most used performers"
+msgstr ""
+
+#: inc/taxonomies.php:144
+msgid "No performers"
+msgstr ""
+
+#: inc/taxonomies.php:145
+msgid "Performers list navigation"
+msgstr ""
+
+#: inc/taxonomies.php:146
+msgid "Performers list"
+msgstr ""
+
+#: inc/taxonomies.php:147
+msgid "Back to performers"
+msgstr ""
+
+#: inc/taxonomies.php:148
+msgctxt "Admin Menu text"
+msgid "Performers"
+msgstr ""
+
+#: inc/taxonomies.php:177
+msgctxt "Taxonomy general name"
+msgid "Genres"
+msgstr ""
+
+#: inc/taxonomies.php:178
+msgctxt "Taxonomy singular name"
+msgid "Genre"
+msgstr ""
+
+#: inc/taxonomies.php:179
+msgid "Search Genres"
+msgstr ""
+
+#: inc/taxonomies.php:180
+msgid "Popular Genres"
+msgstr ""
+
+#: inc/taxonomies.php:181
+msgid "All Genres"
+msgstr ""
+
+#: inc/taxonomies.php:182
+msgid "Parent Genre"
+msgstr ""
+
+#: inc/taxonomies.php:183
+msgid "Parent Genre:"
+msgstr ""
+
+#: inc/taxonomies.php:184
+msgid "Edit Genre"
+msgstr ""
+
+#: inc/taxonomies.php:185
+msgid "View Genre"
+msgstr ""
+
+#: inc/taxonomies.php:186
+msgid "Update Genre"
+msgstr ""
+
+#: inc/taxonomies.php:187
+msgid "Add New Genre"
+msgstr ""
+
+#: inc/taxonomies.php:188
+msgid "New Genre Name"
+msgstr ""
+
+#: inc/taxonomies.php:189
+msgid "Separate genres with commas"
+msgstr ""
+
+#: inc/taxonomies.php:190
+msgid "Add or remove genres"
+msgstr ""
+
+#: inc/taxonomies.php:191
+msgid "Choose from the most used genres"
+msgstr ""
+
+#: inc/taxonomies.php:192
+msgid "No genres found."
+msgstr ""
+
+#: inc/taxonomies.php:193
+msgid "No genres"
+msgstr ""
+
+#: inc/taxonomies.php:194
+msgid "Genres list navigation"
+msgstr ""
+
+#: inc/taxonomies.php:195
+msgid "Genres list"
+msgstr ""
+
+#: inc/taxonomies.php:196
+msgid "Back to genres"
+msgstr ""
+
+#: inc/taxonomies.php:197 sitemap.php:52
+msgid "Genres"
+msgstr ""
+
+#: inc/taxonomies.php:216
+msgctxt "Taxonomy general name"
+msgid "Ad Zones"
+msgstr ""
+
+#: inc/taxonomies.php:217
+msgctxt "Taxonomy singular name"
+msgid "Ad Zone"
+msgstr ""
+
+#: inc/taxonomies.php:218
+msgid "Search Ad Zones"
+msgstr ""
+
+#: inc/taxonomies.php:219
+msgid "Popular Ad Zones"
+msgstr ""
+
+#: inc/taxonomies.php:220
+msgid "All Ad Zones"
+msgstr ""
+
+#: inc/taxonomies.php:221
+msgid "Edit Ad Zone"
+msgstr ""
+
+#: inc/taxonomies.php:222
+msgid "View Ad Zone"
+msgstr ""
+
+#: inc/taxonomies.php:223
+msgid "Update Ad Zone"
+msgstr ""
+
+#: inc/taxonomies.php:224
+msgid "Add New Ad Zone"
+msgstr ""
+
+#: inc/taxonomies.php:225
+msgid "New Ad Zone Name"
+msgstr ""
+
+#: inc/taxonomies.php:226
+msgid "Separate ad zones with commas"
+msgstr ""
+
+#: inc/taxonomies.php:227
+msgid "Add or remove ad zones"
+msgstr ""
+
+#: inc/taxonomies.php:228
+msgid "Choose from the most used ad zones"
+msgstr ""
+
+#: inc/taxonomies.php:229
+msgid "No ad zones found."
+msgstr ""
+
+#: inc/taxonomies.php:230
+msgid "No ad zones"
+msgstr ""
+
+#: inc/taxonomies.php:231
+msgid "Ad Zones list navigation"
+msgstr ""
+
+#: inc/taxonomies.php:232
+msgid "Ad Zones list"
+msgstr ""
+
+#: inc/taxonomies.php:233
+msgid "Back to ad zones"
+msgstr ""
+
+#: inc/taxonomies.php:234
+msgid "Ad Zones"
+msgstr ""
+
+#: inc/taxonomies.php:258 archive-video.php:76
+msgid "Short (0-5 min)"
+msgstr ""
+
+#: inc/taxonomies.php:259 archive-video.php:77
+msgid "Medium (5-20 min)"
+msgstr ""
+
+#: inc/taxonomies.php:260 archive-video.php:78
+msgid "Long (20+ min)"
+msgstr ""
+
+#: inc/taxonomies.php:280
+msgid "Amateur"
+msgstr ""
+
+#: inc/taxonomies.php:281
+msgid "Anal"
+msgstr ""
+
+#: inc/taxonomies.php:282
+msgid "Asian"
+msgstr ""
+
+#: inc/taxonomies.php:283
+msgid "BBW"
+msgstr ""
+
+#: inc/taxonomies.php:284
+msgid "Big Boobs"
+msgstr ""
+
+#: inc/taxonomies.php:285
+msgid "Big Dick"
+msgstr ""
+
+#: inc/taxonomies.php:286
+msgid "Blonde"
+msgstr ""
+
+#: inc/taxonomies.php:287
+msgid "Blowjob"
+msgstr ""
+
+#: inc/taxonomies.php:288
+msgid "Brunette"
+msgstr ""
+
+#: inc/taxonomies.php:289
+msgid "Compilation"
+msgstr ""
+
+#: inc/taxonomies.php:290
+msgid "Creampie"
+msgstr ""
+
+#: inc/taxonomies.php:291
+msgid "Cumshot"
+msgstr ""
+
+#: inc/taxonomies.php:292
+msgid "Ebony"
+msgstr ""
+
+#: inc/taxonomies.php:293
+msgid "Fetish"
+msgstr ""
+
+#: inc/taxonomies.php:294
+msgid "Gangbang"
+msgstr ""
+
+#: inc/taxonomies.php:295
+msgid "Hardcore"
+msgstr ""
+
+#: inc/taxonomies.php:296
+msgid "HD"
+msgstr ""
+
+#: inc/taxonomies.php:297
+msgid "Interracial"
+msgstr ""
+
+#: inc/taxonomies.php:298
+msgid "Latina"
+msgstr ""
+
+#: inc/taxonomies.php:299
+msgid "Lesbian"
+msgstr ""
+
+#: inc/taxonomies.php:300
+msgid "Mature"
+msgstr ""
+
+#: inc/taxonomies.php:301
+msgid "MILF"
+msgstr ""
+
+#: inc/taxonomies.php:302
+msgid "POV"
+msgstr ""
+
+#: inc/taxonomies.php:303
+msgid "Public"
+msgstr ""
+
+#: inc/taxonomies.php:304
+msgid "Redhead"
+msgstr ""
+
+#: inc/taxonomies.php:305
+msgid "Solo"
+msgstr ""
+
+#: inc/taxonomies.php:306
+msgid "Squirt"
+msgstr ""
+
+#: inc/taxonomies.php:307
+msgid "Teen"
+msgstr ""
+
+#: inc/taxonomies.php:308
+msgid "Threesome"
+msgstr ""
+
+#: inc/taxonomies.php:328
+msgid "Header"
+msgstr ""
+
+#: inc/taxonomies.php:329
+msgid "Below Header"
+msgstr ""
+
+#: inc/taxonomies.php:330
+msgid "In Content"
+msgstr ""
+
+#: inc/taxonomies.php:332
+msgid "Footer"
+msgstr ""
+
+#: inc/taxonomies.php:435
+msgid "Search performers..."
+msgstr ""
+
+#: inc/taxonomies.php:461
+msgid "Add New Performer:"
+msgstr ""
+
+#: inc/taxonomies.php:462
+msgid "Enter name"
+msgstr ""
+
+#: inc/taxonomies.php:464
+msgid "Add"
+msgstr ""
+
+#: inc/taxonomies.php:546
+msgid "Please enter a performer name."
+msgstr ""
+
+#: inc/taxonomies.php:572
+msgid "Error adding performer."
+msgstr ""
+
+#: inc/taxonomies.php:576 template-parts/pages/page-register.php:343
+#: template-parts/pages/page-login.php:227
+msgid "An error occurred. Please try again."
+msgstr ""
+
+#: inc/taxonomies.php:690 inc/admin/ffmpeg-settings.php:349
+#: inc/admin/ffmpeg-settings.php:399 inc/admin/ffmpeg-settings.php:594
+msgid "You do not have permission to do this."
+msgstr ""
+
+#: inc/taxonomies.php:697
+msgid "Performer name cannot be empty."
+msgstr ""
+
+#: inc/taxonomies.php:706
+#, php-format
+msgid "Performer \"%s\" assigned successfully."
+msgstr ""
+
+#: inc/taxonomies.php:717
+#, php-format
+msgid "Performer \"%s\" created and assigned successfully."
+msgstr ""
+
+#: inc/thumbnail-extractor.php:389
+msgid "No video source found for this post."
+msgstr ""
+
+#: inc/thumbnail-extractor.php:404 inc/thumbnail-extractor.php:538
+msgid "Failed to download and set the thumbnail image."
+msgstr ""
+
+#: inc/thumbnail-extractor.php:407 inc/thumbnail-extractor.php:541
+msgid "Could not extract a thumbnail from the video source."
+msgstr ""
+
+#: inc/thumbnail-extractor.php:419 inc/thumbnail-extractor.php:534
+msgid "Thumbnail successfully extracted and set as featured image!"
+msgstr ""
+
+#: inc/thumbnail-extractor.php:437
+msgid "Extract Thumbnail from Video"
+msgstr ""
+
+#: inc/thumbnail-extractor.php:473
+msgid "Thumbnail successfully extracted!"
+msgstr ""
+
+#: inc/thumbnail-extractor.php:488
+msgid "Error extracting thumbnail. Please try again."
+msgstr ""
+
+#: inc/permalinks.php:100
+msgid "CustomTube Permalinks"
+msgstr ""
+
+#: inc/permalinks.php:107
+msgid "Video base"
+msgstr ""
+
+#: inc/permalinks.php:119
+msgid ""
+"These settings control the permalinks used for videos in the CustomTube "
+"theme."
+msgstr ""
+
+#: inc/permalinks.php:129
+msgid "Default: \"video\""
+msgstr ""
+
+#: inc/admin/dashboard.php:32 inc/admin/settings.php:20
+msgid "CustomTube Dashboard"
+msgstr ""
+
+#: inc/admin/dashboard.php:36
+msgid "Welcome to CustomTube"
+msgstr ""
+
+#: inc/admin/dashboard.php:37
+msgid ""
+"Your ultimate WordPress theme for organizing and presenting adult video "
+"content."
+msgstr ""
+
+#: inc/admin/dashboard.php:41
+msgid "Quick Actions"
+msgstr ""
+
+#: inc/admin/dashboard.php:44
+msgid "Configure Settings"
+msgstr ""
+
+#: inc/admin/dashboard.php:45
+msgid "Access Tools"
+msgstr ""
+
+#: inc/admin/dashboard.php:49
+msgid "Next Steps"
+msgstr ""
+
+#: inc/admin/dashboard.php:52
+msgid "Start by adding some videos to your site"
+msgstr ""
+
+#: inc/admin/dashboard.php:54
+msgid "Customize your site appearance"
+msgstr ""
+
+#: inc/admin/dashboard.php:55
+msgid "Configure age verification settings"
+msgstr ""
+
+#: inc/admin/dashboard.php:56
+msgid "Set up your video import feeds"
+msgstr ""
+
+#: inc/admin/dashboard.php:60
+msgid "More Actions"
+msgstr ""
+
+#: inc/admin/dashboard.php:62
+msgid "Manage Video Categories"
+msgstr ""
+
+#: inc/admin/dashboard.php:63
+msgid "Manage Video Tags"
+msgstr ""
+
+#: inc/admin/dashboard.php:64
+msgid "Manage Performers"
+msgstr ""
+
+#: inc/admin/dashboard.php:79
+msgid "Video Statistics"
+msgstr ""
+
+#: inc/admin/dashboard.php:86
+msgid "Total Videos"
+msgstr ""
+
+#: inc/admin/dashboard.php:92 template-parts/pages/page-trending.php:83
+msgid "Total Views"
+msgstr ""
+
+#: inc/admin/dashboard.php:98 template-parts/pages/page-home.php:41
+#: template-parts/pages/page-categories.php:25
+#: template-parts/pages/page-likedvideos.php:75
+msgid "Categories"
+msgstr ""
+
+#: inc/admin/dashboard.php:104 sitemap.php:76
+#: template-parts/pages/page-home.php:37
+msgid "Performers"
+msgstr ""
+
+#: inc/admin/dashboard.php:116
+msgid "Latest Videos"
+msgstr ""
+
+#: inc/admin/dashboard.php:125 inc/admin/dashboard.php:181 archive-video.php:88
+msgid "Title"
+msgstr ""
+
+#: inc/admin/dashboard.php:126
+msgid "Date"
+msgstr ""
+
+#: inc/admin/dashboard.php:154
+msgid "View All Videos"
+msgstr ""
+
+#: inc/admin/dashboard.php:157
+msgid "No videos found. Start adding videos to your site."
+msgstr ""
+
+#: inc/admin/dashboard.php:172
+msgid "Popular Videos"
+msgstr ""
+
+#: inc/admin/dashboard.php:208
+msgid ""
+"No data available yet. Views will be tracked as visitors watch your videos."
+msgstr ""
+
+#: inc/admin/dashboard.php:217
+msgid "System Status"
+msgstr ""
+
+#: inc/admin/dashboard.php:223
+msgid "The following issues need your attention:"
+msgstr ""
+
+#: inc/admin/dashboard.php:238
+msgid "All systems are running smoothly!"
+msgstr ""
+
+#: inc/admin/dashboard.php:246
+msgid "CustomTube Version"
+msgstr ""
+
+#: inc/admin/dashboard.php:250
+msgid "WordPress Version"
+msgstr ""
+
+#: inc/admin/dashboard.php:254
+msgid "PHP Version"
+msgstr ""
+
+#: inc/admin/dashboard.php:258
+msgid "Memory Limit"
+msgstr ""
+
+#: inc/admin/dashboard.php:262
+msgid "Max Upload Size"
+msgstr ""
+
+#: inc/admin/dashboard.php:358
+msgid "Age verification is disabled which may expose adult content to minors."
+msgstr ""
+
+#: inc/admin/dashboard.php:360
+msgid "Enable Now"
+msgstr ""
+
+#: inc/admin/dashboard.php:369
+msgid "Your PHP version is outdated. We recommend using PHP 7.4 or later."
+msgstr ""
+
+#: inc/admin/dashboard.php:371
+msgid "Learn More"
+msgstr ""
+
+#: inc/admin/dashboard.php:381
+msgid "Your site has no videos yet. Start adding some content!"
+msgstr ""
+
+#: inc/admin/dashboard.php:383
+msgid "Add Video"
+msgstr ""
+
+#: inc/admin/settings.php:21
+msgid "CustomTube"
+msgstr ""
+
+#: inc/admin/settings.php:32 inc/admin/settings.php:33
+msgid "Dashboard"
+msgstr ""
+
+#: inc/admin/settings.php:42 inc/admin/settings.php:43
+msgid "Settings"
+msgstr ""
+
+#: inc/admin/settings.php:52 inc/admin/settings.php:53
+msgid "Tools"
+msgstr ""
+
+#: inc/admin/settings.php:62 inc/admin/settings.php:63
+#: inc/admin/settings.php:551
+msgid "Import/Export"
+msgstr ""
+
+#: inc/admin/settings.php:84 inc/admin/settings-page.php:42
+msgid "General Settings"
+msgstr ""
+
+#: inc/admin/settings.php:92 inc/admin/settings-page.php:29
+msgid "Age Verification"
+msgstr ""
+
+#: inc/admin/settings.php:100 inc/admin/settings-page.php:64
+msgid "Video Settings"
+msgstr ""
+
+#: inc/admin/settings.php:108 inc/admin/settings-page.php:75
+msgid "SEO Settings"
+msgstr ""
+
+#: inc/admin/settings.php:116 inc/admin/settings-page.php:32
+msgid "Performance"
+msgstr ""
+
+#: inc/admin/settings.php:124
+msgid "Site Logo"
+msgstr ""
+
+#: inc/admin/settings.php:140
+msgid "Default Color Scheme"
+msgstr ""
+
+#: inc/admin/settings.php:149
+msgid "Enable Age Verification"
+msgstr ""
+
+#: inc/admin/settings.php:157
+msgid "Age Verification Text"
+msgstr ""
+
+#: inc/admin/settings.php:165
+msgid "Underage Redirect URL"
+msgstr ""
+
+#: inc/admin/settings.php:173
+msgid "Cookie Expiration (days)"
+msgstr ""
+
+#: inc/admin/settings.php:182
+msgid "Default Video Player"
+msgstr ""
+
+#: inc/admin/settings.php:190
+msgid "Enable Autoplay"
+msgstr ""
+
+#: inc/admin/settings.php:198
+msgid "Enable Hover Previews"
+msgstr ""
+
+#: inc/admin/settings.php:207
+msgid "Enable VideoObject Schema"
+msgstr ""
+
+#: inc/admin/settings.php:215
+msgid "Enable Video Sitemap"
+msgstr ""
+
+#: inc/admin/settings.php:224
+msgid "Enable Lazy Loading"
+msgstr ""
+
+#: inc/admin/settings.php:232
+msgid "Image Optimization Level"
+msgstr ""
+
+#: inc/admin/settings.php:346
+msgid "Configure general settings for your CustomTube site."
+msgstr ""
+
+#: inc/admin/settings.php:350
+msgid "Configure age verification settings for your adult content."
+msgstr ""
+
+#: inc/admin/settings.php:354
+msgid "Configure video player and display settings."
+msgstr ""
+
+#: inc/admin/settings.php:358
+msgid "Configure SEO settings for better video discoverability."
+msgstr ""
+
+#: inc/admin/settings.php:362
+msgid "Configure performance settings for optimal site speed."
+msgstr ""
+
+#: inc/admin/settings.php:376 inc/admin/settings.php:391
+msgid "Select Image"
+msgstr ""
+
+#: inc/admin/settings.php:382
+msgid "Upload or select your site logo."
+msgstr ""
+
+#: inc/admin/settings.php:397
+msgid "Upload or select your mobile logo (optional)."
+msgstr ""
+
+#: inc/admin/settings.php:406
+msgid "Dark Mode"
+msgstr ""
+
+#: inc/admin/settings.php:407
+msgid "Light Mode"
+msgstr ""
+
+#: inc/admin/settings.php:410
+msgid "Select the default color scheme for your site."
+msgstr ""
+
+#: inc/admin/settings.php:421
+msgid "Enable age verification prompt for visitors"
+msgstr ""
+
+#: inc/admin/settings.php:432
+msgid "Customize the text displayed on the age verification prompt."
+msgstr ""
+
+#: inc/admin/settings.php:441
+msgid ""
+"Optional URL to redirect underage visitors (leave empty to show message "
+"instead)."
+msgstr ""
+
+#: inc/admin/settings.php:450
+msgid "Number of days the age verification cookie will be stored."
+msgstr ""
+
+#: inc/admin/settings.php:460
+msgid "Video.js Player"
+msgstr ""
+
+#: inc/admin/settings.php:461
+msgid "Plyr Player"
+msgstr ""
+
+#: inc/admin/settings.php:462
+msgid "Default HTML5 Player"
+msgstr ""
+
+#: inc/admin/settings.php:465
+msgid "Select the default video player for direct video files."
+msgstr ""
+
+#: inc/admin/settings.php:475
+msgid "Enable autoplay for videos (when supported by the browser)"
+msgstr ""
+
+#: inc/admin/settings.php:486
+msgid "Enable hover preview for video thumbnails"
+msgstr ""
+
+#: inc/admin/settings.php:498
+msgid ""
+"Add VideoObject schema markup to video pages for better search engine "
+"visibility"
+msgstr ""
+
+#: inc/admin/settings.php:509
+msgid "Generate a separate video sitemap for search engines"
+msgstr ""
+
+#: inc/admin/settings.php:521
+msgid "Enable lazy loading for images and video thumbnails"
+msgstr ""
+
+#: inc/admin/settings.php:531
+msgid "None"
+msgstr ""
+
+#: inc/admin/settings.php:532
+msgid "Low"
+msgstr ""
+
+#: inc/admin/settings.php:533
+msgid "Medium"
+msgstr ""
+
+#: inc/admin/settings.php:534
+msgid "High"
+msgstr ""
+
+#: inc/admin/settings.php:537
+msgid ""
+"Set the level of image optimization (affects image quality and file size)."
+msgstr ""
+
+#: inc/admin/settings.php:553
+msgid ""
+"The Import/Export functionality requires the CustomTube Video Importer "
+"plugin. Please install and activate it to use this feature."
+msgstr ""
+
+#: inc/admin/tools.php:23
+msgid "CustomTube Tools"
+msgstr ""
+
+#: inc/admin/tools.php:26
+msgid "Fix Embeds"
+msgstr ""
+
+#: inc/admin/tools.php:27
+msgid "Bulk Extractor"
+msgstr ""
+
+#: inc/admin/tools.php:28
+msgid "Reset Views"
+msgstr ""
+
+#: inc/admin/tools.php:29
+msgid "System Info"
+msgstr ""
+
+#: inc/admin/tools.php:77
+#, php-format
+msgid "Processed %1$d videos and fixed %2$d malformed embed codes."
+msgstr ""
+
+#: inc/admin/tools.php:87
+msgid "Fix Malformed Embed Codes"
+msgstr ""
+
+#: inc/admin/tools.php:88
+msgid ""
+"This tool scans your videos for malformed embed codes and attempts to fix "
+"them automatically."
+msgstr ""
+
+#: inc/admin/tools.php:91
+msgid "Common issues that will be fixed:"
+msgstr ""
+
+#: inc/admin/tools.php:93
+msgid "Embed codes with div tags but no iframe"
+msgstr ""
+
+#: inc/admin/tools.php:94
+msgid "URLs incorrectly stored as embed codes"
+msgstr ""
+
+#: inc/admin/tools.php:95
+msgid "Insecure http:// embeds that need upgrading to https://"
+msgstr ""
+
+#: inc/admin/tools.php:96
+msgid "Malformed iframe attributes"
+msgstr ""
+
+#: inc/admin/tools.php:103
+msgid "Scan and Fix Embeds"
+msgstr ""
+
+#: inc/admin/tools.php:131
+#, php-format
+msgid ""
+"Processed %1$d videos from %2$s and successfully extracted %3$d direct URLs. "
+"Failed: %4$d."
+msgstr ""
+
+#: inc/admin/tools.php:142
+msgid "Bulk Direct URL Extractor"
+msgstr ""
+
+#: inc/admin/tools.php:143
+msgid ""
+"This tool extracts direct video URLs from embedded videos for better "
+"playback performance."
+msgstr ""
+
+#: inc/admin/tools.php:146
+msgid "Supported platforms:"
+msgstr ""
+
+#: inc/admin/tools.php:148
+msgid "YouTube (720p max)"
+msgstr ""
+
+#: inc/admin/tools.php:149
+msgid "Vimeo (when enabled by video owner)"
+msgstr ""
+
+#: inc/admin/tools.php:150
+msgid "XHamster (direct MP4 URLs)"
+msgstr ""
+
+#: inc/admin/tools.php:151
+msgid "PornHub (direct MP4 URLs)"
+msgstr ""
+
+#: inc/admin/tools.php:160
+msgid "Extract From"
+msgstr ""
+
+#: inc/admin/tools.php:163
+msgid "All Sources"
+msgstr ""
+
+#: inc/admin/tools.php:164
+msgid "YouTube Only"
+msgstr ""
+
+#: inc/admin/tools.php:165
+msgid "Vimeo Only"
+msgstr ""
+
+#: inc/admin/tools.php:166
+msgid "XHamster Only"
+msgstr ""
+
+#: inc/admin/tools.php:167
+msgid "PornHub Only"
+msgstr ""
+
+#: inc/admin/tools.php:172
+msgid "Process Limit"
+msgstr ""
+
+#: inc/admin/tools.php:175
+msgid "Maximum number of videos to process in one batch."
+msgstr ""
+
+#: inc/admin/tools.php:181
+msgid "Extract Direct URLs"
+msgstr ""
+
+#: inc/admin/tools.php:204
+#, php-format
+msgid "Successfully reset view counts for %d videos."
+msgstr ""
+
+#: inc/admin/tools.php:215
+#, php-format
+msgid "Successfully reset view count for \"%s\"."
+msgstr ""
+
+#: inc/admin/tools.php:221
+msgid "Could not reset view count. Please check if the video ID is valid."
+msgstr ""
+
+#: inc/admin/tools.php:229
+msgid "Reset Video View Counts"
+msgstr ""
+
+#: inc/admin/tools.php:230
+msgid "This tool allows you to reset view counters for your videos."
+msgstr ""
+
+#: inc/admin/tools.php:233
+msgid "Warning: This action cannot be undone!"
+msgstr ""
+
+#: inc/admin/tools.php:234
+msgid ""
+"Resetting view counts will permanently delete view statistics. Consider "
+"exporting your data before proceeding."
+msgstr ""
+
+#: inc/admin/tools.php:242
+msgid "Reset Option"
+msgstr ""
+
+#: inc/admin/tools.php:247
+msgid "Reset all video view counts"
+msgstr ""
+
+#: inc/admin/tools.php:252
+msgid "Reset view count for a specific video"
+msgstr ""
+
+#: inc/admin/tools.php:258
+msgid "Video ID"
+msgstr ""
+
+#: inc/admin/tools.php:261
+msgid "Enter the ID of the video you want to reset."
+msgstr ""
+
+#: inc/admin/tools.php:267
+msgid "Reset View Counts"
+msgstr ""
+
+#: inc/admin/tools.php:267
+msgid ""
+"Are you sure you want to reset the view counts? This action cannot be undone!"
+msgstr ""
+
+#: inc/admin/tools.php:293
+msgid "System Information"
+msgstr ""
+
+#: inc/admin/tools.php:294
+msgid "This information is useful for troubleshooting CustomTube theme issues."
+msgstr ""
+
+#: inc/admin/tools.php:299 inc/admin/tools.php:312
+msgid "Copy System Info"
+msgstr ""
+
+#: inc/admin/tools.php:310 template-parts/pages/page-dmca.php:218
+msgid "Copied!"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:19 inc/admin/ffmpeg-settings.php:73
+#: inc/admin/ffmpeg-settings.php:471
+msgid "FFmpeg & Clips Settings"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:20
+msgid "FFmpeg & Clips"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:76
+msgid ""
+"These settings control how video clips and thumbnails are generated using "
+"FFmpeg. They affect preview clips, highlight reels, and animated thumbnails."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:81
+msgid "FFmpeg Available:"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:81
+msgid "FFmpeg is installed and accessible on this server."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:85
+msgid "FFmpeg Not Available:"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:85
+msgid ""
+"FFmpeg is not installed or not accessible at the configured path. Clip "
+"generation functionality will not work until this is fixed."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:92
+msgid "FFmpeg Configuration"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:95
+msgid "FFmpeg Binary Path"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:98
+msgid "The path to the FFmpeg binary (e.g., /usr/bin/ffmpeg)."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:102
+msgid "FFprobe Binary Path"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:105
+msgid "The path to the FFprobe binary (e.g., /usr/bin/ffprobe)."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:109
+msgid "Clip Output Directory"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:112
+msgid "The directory where generated clips will be stored."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:116
+msgid ""
+"Directory does not exist. It will be created when needed, but ensure the "
+"server has permission to create it."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:118 inc/admin/ffmpeg-settings.php:135
+msgid "Directory exists but is not writable. Please check permissions."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:120 inc/admin/ffmpeg-settings.php:137
+msgid "Directory exists and is writable."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:126
+msgid "Temporary Directory"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:129
+msgid "The directory where temporary files will be stored during processing."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:133
+msgid "Directory does not exist. Please specify a valid directory."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:144
+msgid "Clip Generation Settings"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:147
+msgid "Auto-generate Clips"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:151
+msgid "Automatically generate clips when a new video is uploaded"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:153
+msgid ""
+"When enabled, clips will be generated in the background when a new video is "
+"saved."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:157
+msgid "Preview Clip Size"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:160 inc/admin/ffmpeg-settings.php:183
+msgid "Small (320x180)"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:161 inc/admin/ffmpeg-settings.php:172
+#: inc/admin/ffmpeg-settings.php:184
+msgid "Medium (640x360)"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:162 inc/admin/ffmpeg-settings.php:173
+#: inc/admin/ffmpeg-settings.php:185
+msgid "Large (854x480)"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:163 inc/admin/ffmpeg-settings.php:174
+msgid "HD (1280x720)"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:165
+msgid "The size of generated preview clips."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:169
+msgid "Highlight Clip Size"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:176
+msgid "The size of generated highlight clips."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:180
+msgid "Intro Clip Size"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:187
+msgid "The size of generated intro clips."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:191
+msgid "GIF Animation Size"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:194
+msgid "Tiny (160x90)"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:195 inc/admin/ffmpeg-settings.php:205
+msgid "Small (240x135)"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:196 inc/admin/ffmpeg-settings.php:206
+msgid "Medium (320x180)"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:198
+msgid ""
+"The size of generated GIF animations. Keep small for better performance."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:202
+msgid "WebP Animation Size"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:207
+msgid "Large (480x270)"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:209
+msgid "The size of generated WebP animations. WebP is more efficient than GIF."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:218
+msgid "Generate Clips in Bulk"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:219
+msgid ""
+"You can generate clips for all self-hosted videos that don't already have "
+"clips."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:222
+msgid "Start Bulk Generation"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:223
+msgid ""
+"This process will run in the background. You can close this page after "
+"starting."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:233
+msgid ""
+"This will generate clips for all videos without clips. It may take a "
+"significant amount of server resources. Continue?"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:240
+msgid "Scanning for videos without clips..."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:254
+msgid "No videos found that need clips."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:260
+msgid "Found"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:262
+msgid "videos without clips. Starting processing..."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:276
+msgid "Error counting videos. Please try again."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:300
+msgid "Processing videos..."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:301 inc/admin/ffmpeg-settings.php:323
+msgid "of"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:310
+msgid "Completed processing"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:311 inc/admin/ffmpeg-settings.php:324
+msgid "videos."
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:322
+msgid "Error processing batch. Processed"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:481
+msgid "Clips"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:497
+msgid "External video, clips not available"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:504
+msgid "Generate"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:510
+msgid "Clips available"
+msgstr ""
+
+#: inc/admin/ffmpeg-settings.php:514
+msgid "Generation attempted but no clips available"
+msgstr ""
+
+#: inc/admin/settings-page.php:23
+msgid "CustomTube Settings"
+msgstr ""
+
+#: inc/admin/settings-page.php:28
+msgid "General"
+msgstr ""
+
+#: inc/admin/settings-page.php:30
+msgid "Video"
+msgstr ""
+
+#: inc/admin/settings-page.php:31
+msgid "SEO"
+msgstr ""
+
+#: inc/admin/settings-page.php:53
+msgid "Age Verification Settings"
+msgstr ""
+
+#: inc/admin/settings-page.php:86
+msgid "Performance Settings"
+msgstr ""
+
+#: inc/template-parts/trending-grid.php:22
+#: template-parts/pages/page-trending.php:20
+#: template-parts/pages/page-trending.php:87
+#: template-parts/pages/page-home.php:132
+msgid "Trending Videos"
+msgstr ""
+
+#: sitemap.php:24 archive-video.php:19 archive-video.php:35
+#: template-parts/pages/page-home.php:33
+#: template-parts/pages/page-categories.php:59
+msgid "Videos"
+msgstr ""
+
+#: sitemap.php:68 sitemap.php:92 template-parts/pages/page-shorties.php:169
+msgid "video"
+msgid_plural "videos"
+msgstr[0] ""
+msgstr[1] ""
+
+#: sitemap.php:100
+msgid "Tags"
+msgstr ""
+
+#: sitemap.php:122
+msgid "Pages"
+msgstr ""
+
+#: sitemap.php:144
+msgid "XML Sitemaps"
+msgstr ""
+
+#: sitemap.php:147
+msgid "Video Sitemap (XML)"
+msgstr ""
+
+#: sitemap.php:149
+msgid "For search engines"
+msgstr ""
+
+#: sitemap.php:154
+msgid "WordPress Sitemap (XML)"
+msgstr ""
+
+#: sitemap.php:156
+msgid "Core WordPress sitemap"
+msgstr ""
+
+#: archive-video.php:27
+msgid "Videos Tagged:"
+msgstr ""
+
+#: archive-video.php:49
+#, php-format
+msgid "Search Results for: %s"
+msgstr ""
+
+#: archive-video.php:62
+msgid "Filter & Sort"
+msgstr ""
+
+#: archive-video.php:75
+msgid "Any Duration"
+msgstr ""
+
+#: archive-video.php:83
+msgid "Sort By"
+msgstr ""
+
+#: archive-video.php:85
+msgid "Newest"
+msgstr ""
+
+#: archive-video.php:86 template-parts/pages/page-categories.php:103
+#: template-parts/pages/page-shorties.php:45
+msgid "Most Viewed"
+msgstr ""
+
+#: archive-video.php:87
+msgid "Most Liked"
+msgstr ""
+
+#: archive-video.php:93
+msgid "Apply Filters"
+msgstr ""
+
+#: archive-video.php:94
+msgid "Reset"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:23
+msgid "Discover what's hot and trending right now"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:36
+msgid "Top 5 Trending Now"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:43
+#: template-parts/pages/page-trending.php:106
+msgid "Loading trending videos..."
+msgstr ""
+
+#: template-parts/pages/page-trending.php:55
+#: template-parts/pages/page-home.php:135
+msgid "Today"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:59
+#: template-parts/pages/page-home.php:138
+#: template-parts/pages/page-likedvideos.php:79
+msgid "This Week"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:63
+#: template-parts/pages/page-home.php:141
+msgid "This Month"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:67
+msgid "All Time"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:91
+msgid "Hot Categories"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:95
+msgid "Growth Rate"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:114
+msgid "Load More Trending"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:124
+msgid "No Trending Videos Found"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:127
+msgid "Check back later to see what's trending!"
+msgstr ""
+
+#: template-parts/pages/page-trending.php:158
+#: template-parts/pages/page-shorties.php:88
+#: template-parts/pages/page-shorties.php:150
+#: template-parts/pages/page-likedvideos.php:222
+msgid "Loading..."
+msgstr ""
+
+#: template-parts/pages/page-trending.php:234
+msgid "Error loading trending videos. Please try again."
+msgstr ""
+
+#: template-parts/pages/page-home.php:17
+msgid "Welcome to LustfulClips"
+msgstr ""
+
+#: template-parts/pages/page-home.php:18
+msgid "Your ultimate destination for high-quality adult videos and clips."
+msgstr ""
+
+#: template-parts/pages/page-home.php:22
+msgid "Search for videos..."
+msgstr ""
+
+#: template-parts/pages/page-home.php:54
+msgid "Loading hero content..."
+msgstr ""
+
+#: template-parts/pages/page-home.php:64
+msgid "Explore Top Categories"
+msgstr ""
+
+#: template-parts/pages/page-home.php:65
+msgid "Dive into our most popular video categories."
+msgstr ""
+
+#: template-parts/pages/page-home.php:90
+msgid "View Category"
+msgstr ""
+
+#: template-parts/pages/page-home.php:96
+msgid "No categories found."
+msgstr ""
+
+#: template-parts/pages/page-home.php:105
+msgid "Because you watched..."
+msgstr ""
+
+#: template-parts/pages/page-home.php:109
+msgid "Loading recommendations..."
+msgstr ""
+
+#: template-parts/pages/page-home.php:118
+msgid "You might also like..."
+msgstr ""
+
+#: template-parts/pages/page-home.php:122
+msgid "Loading more suggestions..."
+msgstr ""
+
+#: template-parts/pages/page-home.php:156
+msgid "No trending videos today."
+msgstr ""
+
+#: template-parts/pages/page-home.php:170
+msgid "Stay Updated"
+msgstr ""
+
+#: template-parts/pages/page-home.php:171
+msgid ""
+"Subscribe to our newsletter for the latest videos, updates, and exclusive "
+"content."
+msgstr ""
+
+#: template-parts/pages/page-home.php:174
+#: template-parts/pages/page-register.php:105
+msgid "Enter your email address"
+msgstr ""
+
+#: template-parts/pages/page-home.php:176
+msgid "Subscribe"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:20
+msgid "18 U.S.C. § 2257 Compliance"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:23
+msgid "Record-Keeping Requirements Compliance Statement"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:28
+msgid ""
+"This website is fully compliant with 18 U.S.C. § 2257 and 28 C.F.R. 75 "
+"record-keeping requirements."
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:40
+msgid "Compliance Statement"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:43
+msgid ""
+"All models, actors, actresses and other persons that appear in any visual "
+"depiction of actual sexually explicit conduct appearing or otherwise "
+"contained in this website were over the age of eighteen years at the time of "
+"the creation of such depictions."
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:44
+msgid ""
+"All other visual depictions displayed on this website are exempt from the "
+"provision of 18 U.S.C. § 2257 and 28 C.F.R. 75 because they do not portray "
+"conduct as specifically defined in 18 U.S.C § 2256 (2)(A) through (D), but "
+"are merely indicative of the types of lewd visual depictions of persons of "
+"the age of majority found on this website."
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:45
+msgid ""
+"Moreover, with respect to all visual depictions displayed on this website, "
+"whether of actual sexually explicit conduct, simulated sexual content or "
+"otherwise, all persons in said visual depictions were at least 18 years of "
+"age when said visual depictions were created."
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:58
+#: template-parts/pages/page-2257-compliance.php:72
+msgid "Custodian of Records"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:64
+msgid "Primary Custodian"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:67
+#: template-parts/pages/page-dmca.php:46
+msgid "Name:"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:71
+msgid "Title:"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:75
+msgid "Organization:"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:79
+#: template-parts/pages/page-dmca.php:50
+msgid "Email:"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:88
+msgid "Records Location"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:90
+msgid ""
+"All records required by 18 U.S.C. § 2257 and 28 C.F.R. 75 are kept by the "
+"Custodian of Records at the following location:"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:94
+msgid "Attn: Records Custodian"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:95
+msgid "[Physical Address]"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:96
+msgid "[City, State, ZIP Code]"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:97
+msgid "[Country]"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:110
+msgid "Model Release Form"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:114
+msgid ""
+"Content producers must use our official model release form to ensure "
+"compliance with record-keeping requirements."
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:119
+msgid "Download PDF Form"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:124
+msgid "Download Word Form"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:129
+msgid "Required Documentation:"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:131
+msgid "Completed and signed model release form"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:132
+msgid "Copy of government-issued photo ID"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:133
+msgid "Proof of age verification"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:134
+msgid "Contact information for all participants"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:144
+#: template-parts/pages/page-privacy-policy.php:51
+#: template-parts/pages/page-privacy-policy.php:321
+#: template-parts/pages/page-dmca.php:43
+msgid "Contact Information"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:151
+msgid "Records Inquiries"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:153
+msgid "For record-keeping and compliance questions:"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:162
+msgid "Legal Department"
+msgstr ""
+
+#: template-parts/pages/page-2257-compliance.php:164
+msgid "For legal and compliance matters:"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:20
+#: template-parts/pages/page-register.php:181
+#: template-parts/pages/page-login.php:130
+#: template-parts/age-verification.php:45
+msgid "Privacy Policy"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:23
+msgid ""
+"Your privacy is important to us. This policy explains how we collect, use, "
+"and protect your information."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:27
+#: template-parts/pages/page-dmca.php:27
+#: template-parts/pages/page-terms-of-service.php:27
+msgid "Last updated:"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:39
+msgid "Table of Contents"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:43
+#: template-parts/pages/page-privacy-policy.php:65
+msgid "Information We Collect"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:44
+#: template-parts/pages/page-privacy-policy.php:100
+msgid "How We Use Information"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:45
+#: template-parts/pages/page-privacy-policy.php:151
+msgid "Information Sharing"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:46
+#: template-parts/pages/page-privacy-policy.php:175
+msgid "Data Security"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:47
+#: template-parts/pages/page-privacy-policy.php:208
+msgid "Cookies & Tracking"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:48
+#: template-parts/pages/page-privacy-policy.php:238
+msgid "Your Rights"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:49
+#: template-parts/pages/page-privacy-policy.php:280
+msgid "Age Restrictions"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:50
+#: template-parts/pages/page-privacy-policy.php:298
+msgid "Policy Changes"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:69
+msgid "We collect information to provide better services to all our users."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:74
+msgid "Personal Information"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:75
+msgid ""
+"We may collect the following personal information when you register or use "
+"our services:"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:77
+msgid "Email address and username"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:78
+msgid "Profile information you provide"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:79
+msgid "Communication preferences"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:80
+msgid "Content preferences and viewing history"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:85
+msgid "Technical Information"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:86
+msgid "We automatically collect certain technical information:"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:88
+msgid "IP address and browser information"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:89
+msgid "Device type and operating system"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:90
+msgid "Website usage statistics and analytics"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:91
+msgid "Referral sources and search terms"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:104
+msgid ""
+"We use your information to improve our services and provide you with a "
+"personalized experience."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:110
+msgid "Service Provision"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:112
+msgid "Account management and authentication"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:113
+msgid "Content recommendations"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:114
+msgid "Customer support"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:119
+msgid "Communication"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:121
+msgid "Service updates and notifications"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:122
+msgid "Marketing communications (with consent)"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:123
+msgid "Legal and policy updates"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:128
+msgid "Analytics"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:130
+msgid "Usage pattern analysis"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:131
+msgid "Performance optimization"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:132
+msgid "Content trend analysis"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:137
+msgid "Security"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:139
+msgid "Fraud prevention"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:140
+msgid "Security monitoring"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:141
+msgid "Compliance enforcement"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:155
+msgid ""
+"We do not sell your personal information. We may share information only in "
+"specific circumstances."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:160
+msgid "We may share your information in the following situations:"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:162
+msgid "With your explicit consent"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:163
+msgid "With service providers who assist our operations"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:164
+msgid "When required by law or legal processes"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:165
+msgid "To protect our rights and prevent fraud"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:166
+msgid "In connection with business transactions"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:179
+msgid ""
+"We implement appropriate security measures to protect your personal "
+"information."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:186
+msgid "Encryption"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:187
+msgid "Data encrypted in transit and at rest"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:192
+msgid "Access Control"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:193
+msgid "Limited access on need-to-know basis"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:198
+msgid "Monitoring"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:199
+msgid "Continuous security monitoring"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:212
+msgid ""
+"We use cookies and similar technologies to enhance your browsing experience."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:218
+msgid "Essential Cookies"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:219
+msgid "Required for basic site functionality and security."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:223
+msgid "Analytics Cookies"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:224
+msgid "Help us understand how visitors interact with our website."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:228
+msgid "Preference Cookies"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:229
+msgid "Remember your settings and personalization choices."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:242
+msgid "You have several rights regarding your personal information."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:248
+msgid "Access"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:249
+msgid "Request a copy of your personal data"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:253
+msgid "Correction"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:254
+msgid "Update or correct inaccurate information"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:258
+msgid "Deletion"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:259
+msgid "Request deletion of your personal data"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:263
+msgid "Portability"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:264
+msgid "Export your data in a portable format"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:270
+msgid "To exercise your rights:"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:271
+msgid "Contact us using the information provided in the Contact section below."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:284
+msgid "Our services are restricted to users who are 18 years of age or older."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:289
+msgid ""
+"By using our website, you confirm that you are at least 18 years old. We do "
+"not knowingly collect personal information from minors under 18 years of age."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:290
+msgid ""
+"If you believe we have inadvertently collected information from someone "
+"under 18, please contact us immediately so we can delete such information."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:302
+msgid "We may update this privacy policy from time to time."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:307
+msgid "We will notify you of any material changes to this privacy policy by:"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:309
+msgid "Posting the updated policy on this page"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:310
+msgid "Updating the \"Last Updated\" date"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:311
+msgid "Sending email notifications for significant changes"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:313
+msgid ""
+"Your continued use of our services after any changes constitutes acceptance "
+"of the updated policy."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:325
+msgid "Have questions about this privacy policy? We're here to help."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:333
+msgid "Email"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:335
+msgid "For privacy-related inquiries:"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:344
+msgid "Response Time"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:346
+msgid ""
+"We typically respond to privacy inquiries within 48 hours during business "
+"days."
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:351
+msgid "Data Controller"
+msgstr ""
+
+#: template-parts/pages/page-privacy-policy.php:353
+#: template-parts/pages/page-dmca.php:56
+msgid "Website:"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:20
+msgid "Browse Categories"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:23
+msgid "Home"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:28
+msgid "Explore videos by category and discover new content"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:51
+#, php-format
+msgid "Featured: %s"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:54
+msgid "Discover the hottest videos in this category"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:64
+msgid "Explore Category"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:79
+#: template-parts/pages/page-categories.php:131
+msgid "Filters"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:85
+#: template-parts/pages/page-shorties.php:65
+msgid "All Categories"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:88
+#: template-parts/pages/page-shorties.php:44
+msgid "Most Popular"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:91
+msgid "Recently Updated"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:98
+msgid "Sort by:"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:100
+msgid "Name (A-Z)"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:101
+#: template-parts/pages/page-categories.php:136
+msgid "Video Count"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:102
+msgid "Recently Added"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:140
+#: template-parts/pages/page-categories.php:144
+#: template-parts/pages/page-categories.php:148
+#: template-parts/pages/page-categories.php:152
+#: template-parts/pages/page-shorties.php:169
+msgid "videos"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:159
+msgid "Popular Tags"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:183
+msgid "Clear Filters"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:217
+msgid "Browse Videos"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:243
+msgid "Browse"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:253
+msgid "No Categories Found"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:254
+msgid "Categories will appear here once videos are added."
+msgstr ""
+
+#: template-parts/pages/page-categories.php:270
+msgid "Previous"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:273
+msgid "Page 1 of 1"
+msgstr ""
+
+#: template-parts/pages/page-categories.php:276
+msgid "Next"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:20
+msgid "DMCA Policy"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:23
+msgid "Digital Millennium Copyright Act Compliance and Takedown Procedures"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:39
+msgid "Designated DMCA Agent"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:65
+msgid "Response Timeframes"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:68
+msgid "Acknowledgment:"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:69
+msgid "Within 24 hours"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:72
+msgid "Investigation:"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:73
+msgid "1-3 business days"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:76
+msgid "Action Taken:"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:77
+msgid "Within 7 business days"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:93
+msgid "DMCA Notice Template"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:98
+msgid "Copy and complete the template below:"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:101
+msgid "Copy Template"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:139
+msgid "False Claims & Penalties"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:146
+msgid "Important Legal Warning"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:148
+msgid ""
+"Filing false DMCA claims is perjury and may result in substantial legal "
+"penalties including damages and attorney fees."
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:151
+msgid ""
+"Before filing a DMCA notice, please ensure that you have a good faith belief "
+"that the use is not authorized. Consider whether the use might qualify as "
+"fair use or fall under other copyright exemptions."
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:153
+msgid "Potential Consequences of False Claims:"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:155
+msgid "Legal liability for damages caused by false takedown"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:156
+msgid "Payment of defendant's attorney fees"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:157
+msgid "Potential criminal perjury charges"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:158
+msgid "Permanent record of false claim filing"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:167
+msgid "Contact & Support"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:174
+msgid "DMCA Notices"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:176
+msgid "For copyright takedown requests:"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:185
+msgid "General Questions"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:187
+msgid "For questions about this policy:"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:195
+msgid "Need Help?"
+msgstr ""
+
+#: template-parts/pages/page-dmca.php:196
+msgid ""
+"If you're unsure whether your claim qualifies for DMCA protection, consider "
+"consulting with a qualified attorney before filing a notice."
+msgstr ""
+
+#: template-parts/pages/page-register.php:20
+#: template-parts/pages/page-register.php:211
+#: template-parts/pages/page-register.php:347
+#: template-parts/pages/page-login.php:121
+#: template-parts/pages/page-likedvideos.php:50
+msgid "Create Account"
+msgstr ""
+
+#: template-parts/pages/page-register.php:23
+msgid "Join our community and start exploring amazing content!"
+msgstr ""
+
+#: template-parts/pages/page-register.php:43
+#: template-parts/age-verification.php:32
+msgid "Age Verification Required"
+msgstr ""
+
+#: template-parts/pages/page-register.php:46
+msgid "You must be 18 years or older to create an account."
+msgstr ""
+
+#: template-parts/pages/page-register.php:57
+#: template-parts/pages/page-login.php:42
+#: template-parts/pages/page-login.php:251
+msgid "Google"
+msgstr ""
+
+#: template-parts/pages/page-register.php:61
+#: template-parts/pages/page-login.php:46
+#: template-parts/pages/page-login.php:253
+msgid "Facebook"
+msgstr ""
+
+#: template-parts/pages/page-register.php:67
+msgid "or register with email"
+msgstr ""
+
+#: template-parts/pages/page-register.php:78
+msgid "Username"
+msgstr ""
+
+#: template-parts/pages/page-register.php:86
+msgid "Choose a username"
+msgstr ""
+
+#: template-parts/pages/page-register.php:90
+msgid "3-20 characters, letters, numbers, and underscores only"
+msgstr ""
+
+#: template-parts/pages/page-register.php:97
+msgid "Email Address"
+msgstr ""
+
+#: template-parts/pages/page-register.php:113
+#: template-parts/pages/page-login.php:76
+msgid "Password"
+msgstr ""
+
+#: template-parts/pages/page-register.php:121
+msgid "Create a strong password"
+msgstr ""
+
+#: template-parts/pages/page-register.php:138
+msgid "Confirm Password"
+msgstr ""
+
+#: template-parts/pages/page-register.php:146
+msgid "Confirm your password"
+msgstr ""
+
+#: template-parts/pages/page-register.php:154
+msgid "Date of Birth"
+msgstr ""
+
+#: template-parts/pages/page-register.php:166
+msgid "You must be 18 or older to register"
+msgstr ""
+
+#: template-parts/pages/page-register.php:175
+msgid "I agree to the"
+msgstr ""
+
+#: template-parts/pages/page-register.php:177
+#: template-parts/pages/page-terms-of-service.php:20
+#: template-parts/pages/page-login.php:133
+#: template-parts/age-verification.php:49
+msgid "Terms of Service"
+msgstr ""
+
+#: template-parts/pages/page-register.php:179
+msgid "and"
+msgstr ""
+
+#: template-parts/pages/page-register.php:192
+msgid ""
+"I confirm that I am 18 years of age or older and I am legally allowed to "
+"view adult content in my location."
+msgstr ""
+
+#: template-parts/pages/page-register.php:202
+msgid ""
+"I would like to receive updates, promotions, and news via email (optional)"
+msgstr ""
+
+#: template-parts/pages/page-register.php:222
+msgid "Already have an account?"
+msgstr ""
+
+#: template-parts/pages/page-register.php:225
+#: template-parts/pages/page-login.php:20
+#: template-parts/pages/page-login.php:107
+#: template-parts/pages/page-login.php:231
+#: template-parts/pages/page-likedvideos.php:46
+msgid "Sign In"
+msgstr ""
+
+#: template-parts/pages/page-register.php:235
+msgid "Your Privacy Matters"
+msgstr ""
+
+#: template-parts/pages/page-register.php:238
+msgid ""
+"We take your privacy seriously. Your personal information is encrypted and "
+"secure, and we never share it with third parties without your consent."
+msgstr ""
+
+#: template-parts/pages/page-register.php:309
+msgid "Creating Account..."
+msgstr ""
+
+#: template-parts/pages/page-register.php:339
+msgid "Registration failed. Please try again."
+msgstr ""
+
+#: template-parts/pages/page-register.php:358
+msgid "Username must be at least 3 characters long."
+msgstr ""
+
+#: template-parts/pages/page-register.php:365
+msgid "Please enter a valid email address."
+msgstr ""
+
+#: template-parts/pages/page-register.php:374
+msgid "Password must be at least 8 characters long."
+msgstr ""
+
+#: template-parts/pages/page-register.php:379
+msgid "Passwords do not match."
+msgstr ""
+
+#: template-parts/pages/page-register.php:386
+msgid "You must be 18 years or older to register."
+msgstr ""
+
+#: template-parts/pages/page-register.php:392
+msgid "You must agree to the Terms of Service and Privacy Policy."
+msgstr ""
+
+#: template-parts/pages/page-register.php:398
+msgid "You must confirm that you are 18 years or older."
+msgstr ""
+
+#: template-parts/pages/page-register.php:410
+msgid "At least 8 characters"
+msgstr ""
+
+#: template-parts/pages/page-register.php:413
+msgid "Lowercase letter"
+msgstr ""
+
+#: template-parts/pages/page-register.php:416
+msgid "Uppercase letter"
+msgstr ""
+
+#: template-parts/pages/page-register.php:419
+msgid "Number"
+msgstr ""
+
+#: template-parts/pages/page-register.php:422
+msgid "Special character"
+msgstr ""
+
+#: template-parts/pages/page-register.php:432
+msgid "Very Weak"
+msgstr ""
+
+#: template-parts/pages/page-register.php:432
+msgid "Weak"
+msgstr ""
+
+#: template-parts/pages/page-register.php:432
+msgid "Fair"
+msgstr ""
+
+#: template-parts/pages/page-register.php:432
+msgid "Good"
+msgstr ""
+
+#: template-parts/pages/page-register.php:432
+msgid "Strong"
+msgstr ""
+
+#: template-parts/pages/page-register.php:446
+msgid "Missing:"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:23
+msgid "Please read these terms carefully before using our services."
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:39
+msgid "What You Need to Know"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:43
+msgid "Age Requirement:"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:44
+msgid "You must be 18+ to use this service"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:47
+msgid "User Conduct:"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:48
+msgid "No illegal or harmful content allowed"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:51
+msgid "Privacy:"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:52
+msgid "We protect your data per our Privacy Policy"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:55
+msgid "Termination:"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:56
+msgid "We may suspend accounts for violations"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:68
+msgid "Quick Navigation"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:70
+msgid "1. Acceptance of Terms"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:71
+msgid "2. Eligibility"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:72
+msgid "3. User Conduct"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:73
+msgid "4. Content Policy"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:74
+msgid "5. Intellectual Property"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:75
+msgid "6. Privacy"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:76
+msgid "7. Disclaimers"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:77
+msgid "8. Limitation of Liability"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:78
+msgid "9. Termination"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:79
+msgid "10. Governing Law"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:80
+msgid "11. Modifications"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:81
+msgid "12. Contact"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:89
+msgid "Acceptance of Terms"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:92
+msgid ""
+"By accessing or using our website and services, you agree to be bound by "
+"these Terms of Service and all applicable laws and regulations. If you do "
+"not agree with any of these terms, you are prohibited from using or "
+"accessing this site."
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:97
+msgid ""
+"Important: By continuing to use our services, you acknowledge that you have "
+"read, understood, and agree to these terms."
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:101
+msgid ""
+"These terms constitute a legally binding agreement between you and our "
+"service. Your use of the service is also governed by our Privacy Policy, "
+"which is incorporated by reference into these terms."
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:109
+msgid "Download PDF Version"
+msgstr ""
+
+#: template-parts/pages/page-terms-of-service.php:114
+msgid "For questions about these terms, please contact us at"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:20
+msgid "Quick clips and highlights - perfect for a quick watch"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:28
+msgid "All Short Videos"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:31
+msgid "Under 30s"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:34
+msgid "Under 1 min"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:37
+msgid "Under 3 min"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:43
+msgid "Newest First"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:46
+msgid "Shortest First"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:47
+msgid "Random"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:97
+msgid "Loading short videos..."
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:105
+#: template-parts/pages/page-likedvideos.php:140
+msgid "Load More Videos"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:115
+msgid "No Short Videos Found"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:118
+msgid "Try adjusting your filters or check back later for new content."
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:122
+msgid "Reset Filters"
+msgstr ""
+
+#: template-parts/pages/page-shorties.php:208
+msgid "Error loading videos. Please try again."
+msgstr ""
+
+#: template-parts/pages/page-login.php:23
+msgid "Welcome back! Please sign in to your account."
+msgstr ""
+
+#: template-parts/pages/page-login.php:52
+msgid "or"
+msgstr ""
+
+#: template-parts/pages/page-login.php:61
+msgid "Username or Email"
+msgstr ""
+
+#: template-parts/pages/page-login.php:69
+msgid "Enter your username or email"
+msgstr ""
+
+#: template-parts/pages/page-login.php:84
+msgid "Enter your password"
+msgstr ""
+
+#: template-parts/pages/page-login.php:95
+msgid "Remember me"
+msgstr ""
+
+#: template-parts/pages/page-login.php:99
+msgid "Forgot password?"
+msgstr ""
+
+#: template-parts/pages/page-login.php:118
+msgid "Don't have an account?"
+msgstr ""
+
+#: template-parts/pages/page-login.php:136
+msgid "Help & Support"
+msgstr ""
+
+#: template-parts/pages/page-login.php:185
+msgid "Please enter your username or email."
+msgstr ""
+
+#: template-parts/pages/page-login.php:190
+msgid "Please enter your password."
+msgstr ""
+
+#: template-parts/pages/page-login.php:197
+msgid "Signing In..."
+msgstr ""
+
+#: template-parts/pages/page-login.php:223
+msgid "Login failed. Please try again."
+msgstr ""
+
+#: template-parts/pages/page-login.php:241
+msgid "Connecting..."
+msgstr ""
+
+#: template-parts/pages/page-login.php:245
+msgid "Social login is not configured yet."
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:20
+#: template-parts/pages/page-likedvideos.php:67
+msgid "Liked Videos"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:23
+msgid "Your favorite videos, saved for easy access"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:38
+msgid "Sign In to View Your Liked Videos"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:41
+msgid ""
+"Create an account or sign in to start liking videos and building your "
+"personal collection."
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:71
+msgid "Total Duration"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:96
+msgid "Search your liked videos..."
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:103
+msgid "Recently Liked"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:104
+msgid "Oldest First"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:105
+msgid "Title (A-Z)"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:120
+msgid "Clear All"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:132
+msgid "Loading your liked videos..."
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:150
+msgid "No Liked Videos Yet"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:153
+msgid "Start exploring and like videos to build your personal collection!"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:157
+msgid "Discover Videos"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:165
+msgid "videos selected"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:170
+msgid "Unlike Selected"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:174
+msgid "Add to Playlist"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:178
+msgid "Share Selected"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:182
+msgid "Clear Selection"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:279
+msgid "Error loading liked videos. Please try again."
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:322
+#: template-parts/pages/page-likedvideos.php:440
+msgid "Unlike"
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:432
+msgid ""
+"Are you sure you want to unlike all videos? This action cannot be undone."
+msgstr ""
+
+#: template-parts/pages/page-likedvideos.php:440
+msgid "selected videos?"
+msgstr ""
+
+#: template-parts/category-tags-nav.php:123
+msgid "More"
+msgstr ""
+
+#: template-parts/category-tags-nav.php:138
+msgid "Trending:"
+msgstr ""
+
+#: template-parts/pagination.php:31
+msgid "« Previous"
+msgstr ""
+
+#: template-parts/pagination.php:32
+msgid "Next »"
+msgstr ""
+
+#: template-parts/pagination.php:33
+msgid "Posts navigation"
+msgstr ""
+
+#: template-parts/age-verification.php:39
+msgid "I am 18 or older"
+msgstr ""
+
+#: template-parts/age-verification.php:40
+msgid "I am under 18"
+msgstr ""
+
+#: template-parts/age-verification.php:107
+msgid "You must be at least 18 years old to view this website."
+msgstr ""
+
+#: template-parts/enhanced-navigation.php:39
+msgid "Toggle navigation menu"
+msgstr ""
+
+#: template-parts/enhanced-navigation.php:53
+#: template-parts/enhanced-navigation.php:103
+msgid "Search videos..."
+msgstr ""
+
+#: template-parts/enhanced-navigation.php:55
+#: template-parts/enhanced-navigation.php:105
+msgid "Search"
+msgstr ""
+
+#: template-parts/enhanced-navigation.php:97
+msgid "Mobile navigation"
+msgstr ""


### PR DESCRIPTION
## Summary
- generate a new POT file for translations in `languages/`
- load the theme text domain from `languages`
- explain how to update translations in the README

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6871d15cebe48327a599504130d74cab